### PR TITLE
이메일 회원가입 기본 정보 입력 제출 폼 구현

### DIFF
--- a/src/app/signup/[token]/error.tsx
+++ b/src/app/signup/[token]/error.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="grid w-full h-dvh place-items-center">
+      <div>
+        <h4 className="text-2xl font-bold md:text-3xl">오류 🚨</h4>
+        <p className="mt-2 text-center">{error.message}</p>
+        <button onClick={() => reset()}>재시도하기</button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/[token]/loading.tsx
+++ b/src/app/signup/[token]/loading.tsx
@@ -1,0 +1,12 @@
+import { HeadingWithDescription } from '@/components/HeadingWithDescription/HeadingWithDescription';
+
+export default function Loading() {
+  return (
+    <div className="grid w-full h-dvh place-items-center">
+      <div>
+        <h4 className="text-2xl font-bold md:text-3xl">잠시만 기다려주세요 🦊</h4>
+        <p className="mt-2 text-center">필요한 정보를 불러오는 중이에요...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/[token]/page.tsx
+++ b/src/app/signup/[token]/page.tsx
@@ -3,12 +3,26 @@ import { GongsilockLogo } from '@/components/GongsilockLogo/GongsilockLogo';
 import { HeadingWithDescription } from '@/components/HeadingWithDescription/HeadingWithDescription';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { getVerifiedEmailFromToken } from '../_actions/actions';
 
 type PageProps = {
   params: { token: string };
 };
-export default function Page({ params }: PageProps) {
+export default async function Page({ params }: PageProps) {
   const { token } = params;
+
+  if (!token) {
+    throw new Error('token이 없음');
+  }
+
+  const { status, payload } = await getVerifiedEmailFromToken(token);
+
+  // TODO: 500 상태 Enum으로 작성, status 비교하는 타입 가드 함수 작성
+  if (status === 500) {
+    throw new Error(JSON.stringify(payload));
+  }
+
+  const { email: verifiedEmail } = payload;
 
   const handleSuccess = async () => {
     'use server';
@@ -24,7 +38,7 @@ export default function Page({ params }: PageProps) {
       </Link>
 
       <HeadingWithDescription heading="기본 정보 입력" description="공시락 서비스에 필요한 정보를 입력해주세요." />
-      <SignUpForm onSuccess={handleSuccess} />
+      <SignUpForm onSuccess={handleSuccess} defaultValues={{ email: verifiedEmail }} />
     </section>
   );
 }

--- a/src/app/signup/_actions/actions.ts
+++ b/src/app/signup/_actions/actions.ts
@@ -1,0 +1,54 @@
+/**
+ * NOTE: API 문서들이 다 완료가 된 이후에 API 타입에 대한 코드를 작성하려고 했는데
+ * 기본 응답 형식이 정해진 이상 공통 타입으로 빼야할 듯 함.
+ * PM한테 이슈 작성 요구
+ */
+
+'use server';
+
+const requestEchoAPI = <T>(result: T) => {
+  return new Promise<T>((resolve) => {
+    const timerId = setTimeout(() => {
+      resolve(result);
+      clearTimeout(timerId);
+    }, 1500);
+  });
+};
+
+/** TODO: API 응답 타입들은 전체 types 폴더로 옮기기 */
+type SuccessResponse<T> = {
+  status: 200;
+  payload: T;
+};
+
+type ErrorResponse = {
+  status: 500;
+  payload: ErrorObject;
+};
+
+type ErrorObject = {
+  errorCode: number;
+  errorMessage: string;
+};
+
+type APIResponse<T> = SuccessResponse<T> | ErrorResponse;
+
+type GetVerifiedEmailFromTokenResponse = {
+  email: string;
+};
+
+/**
+ * Note: 테스트용 API
+ * _withSuccess()는 들어온 인자 타입 그대로 반환합니다.
+ * _withError()는 ErrorResponse를 반환합니다.
+ * */
+const _withSuccess = <T>(result: T) => ({ status: 200, payload: result } as APIResponse<T>);
+const _withError = (errorObject: ErrorObject) => ({ status: 500, payload: errorObject } as ErrorResponse);
+
+export const getVerifiedEmailFromToken = async (token: string) => {
+  if (token == 'test_invalid') {
+    return await requestEchoAPI(_withError({ errorCode: 1101, errorMessage: '이메일 중복' }));
+  }
+
+  return await requestEchoAPI(_withSuccess({ email: 'text@example.com' } as GetVerifiedEmailFromTokenResponse));
+};

--- a/src/app/signup/_forms/SignUpForm.tsx
+++ b/src/app/signup/_forms/SignUpForm.tsx
@@ -20,6 +20,7 @@ const MAX_UPLOAD_SIZE = 1024 * 1024 * 3; // 3MB
 const ACCEPTED_FILE_TYPES = ['image/png'];
 
 const formSchema = z.object({
+  email: z.string(),
   username: z.string().min(2, {
     message: '이름은 최소 2글자 이상',
   }),
@@ -37,21 +38,23 @@ const formSchema = z.object({
 export type SignUpRequest = z.infer<typeof formSchema>;
 
 const initialValues: SignUpRequest = {
+  email: '',
   username: '',
   // profileImage: undefined,
 };
 
 type SignUpFormProp = {
+  defaultValues: { email: string };
   onSuccess: () => void;
 };
 
-export function SignUpForm({ onSuccess }: SignUpFormProp) {
+export function SignUpForm({ onSuccess, defaultValues }: SignUpFormProp) {
   const [isPending, startTransition] = useTransition();
   const formRef = useRef<HTMLFormElement>(null);
 
   const [state, setState] = useState<FormState>({
     status: ActionStatus.Idle,
-    fields: { ...initialValues },
+    fields: { ...initialValues, ...defaultValues },
   });
 
   const form = useForm<SignUpRequest>({
@@ -97,6 +100,7 @@ export function SignUpForm({ onSuccess }: SignUpFormProp) {
         className="w-full flex-1 flex"
         encType="multipart/form-data">
         <fieldset className="flex-1 flex flex-col border-none space-y-6" disabled={isPending}>
+          <EmailField control={form.control} />
           <UsernameField control={form.control} />
           {/* <ProfileField control={form.control} /> */}
           {hasError && <p>{state.issues[0]}</p>}
@@ -106,6 +110,25 @@ export function SignUpForm({ onSuccess }: SignUpFormProp) {
     </Form>
   );
 }
+
+const EmailField = ({ control }: { control: Control<SignUpRequest, any> }) => {
+  return (
+    <FormField
+      control={control}
+      name="email"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>이메일*</FormLabel>
+          <FormDescription>해당 이메일로 가입될 예정입니다.</FormDescription>
+          <FormControl>
+            <Input type="email" {...field} disabled />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
 
 const UsernameField = ({ control }: { control: Control<SignUpRequest, any> }) => {
   return (


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #41 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- /signup/:token 경로에 대한 error.tsx 및 loading.tsx 작성
- 테스트용 Email Validation API 작성
- 이메일 회원가입 화면에 Email 필드 추가
- 검증된 이메일 가져오는 Server Action 작성 (getVerifiedEmailFromToken)

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- API 문서가 완료된 이후에 API 응답 타입을 작성하려고 해서 지금까진 테스트용으로 작성하고 있었는데, 응답 형식이 정해진 이상 서비스 공용 타입에 API 응답 타입을 작성해야 할 것 같음. 이슈 생성 예정.
- API 타입 이슈에 대한 작업 진행할 때, API 호출 관련 흐름 정리하면 좋을 듯!
