### PR TITLE
Backend API 호출 Server Actions 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "devs": "next dev --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-slot": "^1.0.2",
+    "axios": "^1.7.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.0.2
         version: 1.0.2(@types/react@18.2.79)(react@18.2.0)
+      axios:
+        specifier: ^1.7.1
+        version: 1.7.1
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -705,6 +708,9 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -712,6 +718,9 @@ packages:
   axe-core@4.7.0:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
+
+  axios@1.7.1:
+    resolution: {integrity: sha512-+LV37nQcd1EpFalkXksWNBiA17NZ5m5/WspmHGmZmdx1qBOg/VNq/c4eRJiA9VQQHBOs+N0ZhhdU10h2TyNK7Q==}
 
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -798,6 +807,10 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -875,6 +888,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1106,12 +1123,25 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
+  follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
   foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
+
+  form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
 
   framer-motion@11.1.7:
     resolution: {integrity: sha512-cW11Pu53eDAXUEhv5hEiWuIXWhfkbV32PlgVISn7jRdcAiVrJ1S03YQQ0/DzoswGYYwKi4qYmHHjCzAH52eSdQ==}
@@ -1478,6 +1508,14 @@ packages:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1731,6 +1769,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2680,11 +2721,21 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
 
   axe-core@4.7.0: {}
+
+  axios@1.7.1:
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@3.2.1:
     dependencies:
@@ -2780,6 +2831,10 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
@@ -2848,6 +2903,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -3232,6 +3289,8 @@ snapshots:
 
   flatted@3.3.1: {}
 
+  follow-redirects@1.15.6: {}
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -3240,6 +3299,12 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
+
+  form-data@4.0.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   framer-motion@11.1.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -3589,6 +3654,12 @@ snapshots:
       braces: 3.0.2
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -3838,6 +3909,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/app/actions/auth.actions.ts
+++ b/src/app/actions/auth.actions.ts
@@ -1,0 +1,33 @@
+'use server';
+
+import { HTTPMethod, requestAPI } from '@/lib/fetcher';
+
+const BASE_API_URL = 'https://dosilock.kro.kr/api/v1';
+// const BASE_API_URL = process.env.NODE_ENV === 'development' ? 'localhost:3000' : process.env.BASE_API_URL;
+const AUTH_API_URL = `${BASE_API_URL}/auth`;
+
+const AUTH_ENDPOINT = {
+  Default: `${AUTH_API_URL}`,
+  SignUp: `${AUTH_API_URL}/signup`,
+  SignupLink: `${AUTH_API_URL}/signup/link`,
+  ResetPasswordLink: `${AUTH_API_URL}/reset-password-link`,
+  Login: `${AUTH_API_URL}/signin`,
+};
+
+// const AUTH_ENDPOINT = {
+//   ResetPasswordLink: `${AUTH_API_URL}/reset-password-link`,
+//   SignupLink: `${AUTH_API_URL}/signup/link`,
+//   Signup: `${AUTH_API_URL}/signup`,
+//   Login: `${AUTH_API_URL}/login`,
+// };
+
+export type LoginServiceRequest = {
+  email: string;
+  password: string;
+};
+
+const testEndpoint = `${BASE_API_URL}/signin`;
+export const loginService = async (payload: LoginServiceRequest) => {
+  return await requestAPI<EmptyResponse, LoginServiceRequest>(HTTPMethod.POST, testEndpoint, {}, payload);
+  // return await requestAPI<EmptyResponse, LoginServiceRequest>(HTTPMethod.POST, AUTH_ENDPOINT.Login, payload);
+};

--- a/src/app/actions/auth.actions.ts
+++ b/src/app/actions/auth.actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
-import { HTTPMethod, requestAPI } from '@/lib/fetcher';
+import { requestAPI } from '@/lib/fetcher';
+import { HTTPMethod } from '@/types/api';
 
 const BASE_API_URL = 'https://dosilock.kro.kr/api/v1';
 // const BASE_API_URL = process.env.NODE_ENV === 'development' ? 'localhost:3000' : process.env.BASE_API_URL;
@@ -28,6 +29,5 @@ export type LoginServiceRequest = {
 
 const testEndpoint = `${BASE_API_URL}/signin`;
 export const loginService = async (payload: LoginServiceRequest) => {
-  return await requestAPI<EmptyResponse, LoginServiceRequest>(HTTPMethod.POST, testEndpoint, {}, payload);
-  // return await requestAPI<EmptyResponse, LoginServiceRequest>(HTTPMethod.POST, AUTH_ENDPOINT.Login, payload);
+  return await requestAPI<null, LoginServiceRequest>(HTTPMethod.POST, testEndpoint, payload);
 };

--- a/src/app/actions/class.actions.ts
+++ b/src/app/actions/class.actions.ts
@@ -1,0 +1,28 @@
+'use server';
+
+const BASE_API_URL = process.env.NODE_ENV === 'development' ? 'localhost:3000' : process.env.BASE_API_URL;
+const CLAZZ_API_URL = `${BASE_API_URL}/clazz`;
+
+const CLAZZ_ENDPOINT = {
+  Default: `${CLAZZ_API_URL}`,
+  At: (clazzId: string) => `${CLAZZ_API_URL}/${clazzId}`,
+  MembersOf: (clazzId: string) => `${CLAZZ_API_URL}/${clazzId}/members`,
+};
+
+// const CLAZZ_ENDPOINT = {
+//   GetMembers: (clazzId: string) => `${CLAZZ_API_URL}/${clazzId}/members`,
+//   ApproveMember: (clazzId: string) => `${CLAZZ_API_URL}/${clazzId}/members/approve`,
+//   RejectMember: (clazzId: string) => `${CLAZZ_API_URL}/${clazzId}/members/reject`,
+//   ApplyToClazz: (clazzId: string) => `${CLAZZ_API_URL}/${clazzId}/members/apply`,
+//   CreateClazz: `${CLAZZ_API_URL}`,
+//   ClazzDetails: (clazzId: string) => `${CLAZZ_API_URL}/${clazzId}`,
+// };
+
+export const fetchClazzDetails = async (clazzId: string) => {
+  return await fetch(CLAZZ_ENDPOINT.At(clazzId), {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};

--- a/src/app/actions/index.ts
+++ b/src/app/actions/index.ts
@@ -1,0 +1,26 @@
+/**
+ * NOTE: API Server Actions 네이밍 관련
+ * - 서버에서 가져오는 행위라는 것을 명확하게 해주기 위해 get 대신 fetch 접두어 사용
+ * - 서버에서 가져온 정보는 Info가 아닌 Data 또는 Details이 될 수 있음
+ *   -> 가공되지 않은 정보 개념으로 접근
+ *
+ * EndPoints의 각 필드는 행위를 명시적으로 나타낼 수 있도록 명명
+ * 필드의 네이밍 컨벤션을 마찬가지로 SCREAMING_SNAKE_CASE로 하려다가
+ * 너무 시끄러워서 파스칼로 지정
+ * ex) AUTH_ENDPOINT.ResetPasswordLink
+ *
+ * 근데 행위가 아니라 그냥 Depth로 가져가는 게 나을 것 같기도 하고... 요건 써보면서 고민해보기
+ */
+
+/**
+ * Server Action 시나리오
+ *
+ * 1. 정상 응답
+ * 2. 에러 응답
+ * 3. fetch 오류
+ */
+
+export * from './auth.actions';
+export * from './class.actions';
+export * from './timetable.actions';
+export * from './users.actions';

--- a/src/app/actions/timetable.actions.ts
+++ b/src/app/actions/timetable.actions.ts
@@ -1,0 +1,18 @@
+'use server';
+
+const BASE_API_URL = process.env.NODE_ENV === 'development' ? 'localhost:3000' : process.env.BASE_API_URL;
+const TIMETABLE_API_URL = `${BASE_API_URL}/timetable`;
+
+const TIMETABLE_ENDPOINT = {
+  Default: `${TIMETABLE_API_URL}`,
+  At: (timetableId: string) => `${TIMETABLE_API_URL}/${timetableId}`,
+};
+
+export const fetchTimetableDetails = async (timetableId: string) => {
+  return await fetch(TIMETABLE_ENDPOINT.At(timetableId), {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};

--- a/src/app/actions/users.actions.ts
+++ b/src/app/actions/users.actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+const BASE_API_URL = process.env.NODE_ENV === 'development' ? 'localhost:3000' : process.env.BASE_API_URL;
+const USERS_API_URL = `${BASE_API_URL}/users`;
+
+const USERS_ENDPOINT = {
+  Default: `${USERS_API_URL}`,
+  At: (userId: string) => `${USERS_API_URL}/${userId}`,
+  resetPassword: `${USERS_API_URL}/reset-password`,
+  mypage: `${USERS_API_URL}/me`,
+  myClazz: `${USERS_API_URL}/me/clazz`,
+};
+
+export const fetchMyDetails = async () => {
+  return await fetch(USERS_ENDPOINT.mypage, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};

--- a/src/app/actions/validate.actions.ts
+++ b/src/app/actions/validate.actions.ts
@@ -1,0 +1,17 @@
+'use server';
+
+const BASE_API_URL = process.env.NODE_ENV === 'development' ? 'localhost:3000' : process.env.BASE_API_URL;
+
+const VALIDATE_ENDPOINT = {
+  validate: `${BASE_API_URL}/validate-token`,
+};
+
+export const validateToken = async (token: string) => {
+  return await fetch(VALIDATE_ENDPOINT.validate, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ token }),
+  });
+};

--- a/src/app/login/_forms/LoginForm.tsx
+++ b/src/app/login/_forms/LoginForm.tsx
@@ -1,14 +1,17 @@
 'use client';
 
+import { LoginServiceRequest, loginService } from '@/app/actions';
 import { Button } from '@/components/ui/button';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { FetchStatus } from '@/lib/fetcher';
+import { ActionStatus } from '@/types/actions';
 import { ErrorObject } from '@/types/api';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { Control, useForm } from 'react-hook-form';
 import { z } from 'zod';
-import { loginService } from './LoginForm.action';
+// import { loginService } from './LoginForm.action';
 
 const formSchema = z.object({
   email: z.string().email('이메일 형식을 따라주셈'),
@@ -57,13 +60,33 @@ export const LoginForm = ({ onSuccess }: LoginFormProps) => {
     setErrorState(null);
     setIsPending(true);
 
-    const { status, payload } = await loginService(loginValues);
+    const { status: actionStatus, actionResponse } = await loginService(loginValues);
 
-    if (status === 500) {
-      setErrorState(payload);
-      setIsPending(false);
+    console.log({ actionStatus });
+
+    if (actionStatus === ActionStatus.NETWORK_ERROR) {
+      // TODO: Toast 띄우기
+      return;
     }
 
+    const { status, fetchResponse } = actionResponse;
+
+    console.log({ status });
+
+    if (status === FetchStatus.FAIL) {
+      console.log({ actionResponse });
+      // 실패 응답
+      const { payload: errorObject } = fetchResponse;
+
+      console.log({ errorObject });
+
+      setErrorState(errorObject);
+      setIsPending(false);
+
+      return;
+    }
+
+    // 성공 응답
     return onSuccess();
   };
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,25 +1,17 @@
+import { GongsilockLogo } from '@/components/GongsilockLogo/GongsilockLogo';
 import { SocialLogins } from '@/components/SocialLogins/SocialLogins';
 import Image from 'next/image';
 import Link from 'next/link';
 import fox from '../../static/images/fox.jpg';
 import { LoginForm } from './_forms/LoginForm';
-import { redirect } from 'next/navigation';
-import { GongsilockLogo } from '@/components/GongsilockLogo/GongsilockLogo';
 
 export default function Home() {
-  const handleSuccess = async () => {
-    'use server';
-
-    console.log('성공성공~');
-    redirect('/class');
-  };
-
   return (
     <section className="flex h-dvh items-center">
       <div className="flex-1 flex flex-row rounded-xl overflow-hidden mx-auto lg:max-w-[min(100dvw-9rem,75rem)]">
         <div className="flex-1 flex flex-col gap-12 p-6">
           <GongsilockLogo />
-          <LoginForm onSuccess={handleSuccess} />
+          <LoginForm redirectUrl="/class" />
           <SocialLogins />
 
           <Link className="underline w-full text-center" href="/reset-password">

--- a/src/axios/serverAxios.ts
+++ b/src/axios/serverAxios.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+const BACKEND_API_URL = process.env.BACKEND_API_URL;
+
+/** 서버에서는 요청 시마다 Axios Instance를 생성해주는 게 맞...다? */
+export const createServerAxios = () =>
+  axios.create({
+    baseURL: BACKEND_API_URL,
+  });

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,0 +1,140 @@
+import { ActionResponse, ActionStatus } from '@/types/actions';
+import { APIResponse, ErrorResponse, SuccessResponse } from '@/types/api';
+
+export enum FetchStatus {
+  SUCCESS = 'success',
+  FAIL = 'fail',
+}
+
+export type FetchSuccessResponse<T> = {
+  status: FetchStatus.SUCCESS;
+  fetchResponse: SuccessResponse<T>;
+};
+
+export type FetchFailResponse = {
+  status: FetchStatus.FAIL;
+  fetchResponse: ErrorResponse;
+};
+
+export type FetchResponse<T> = FetchSuccessResponse<T> | FetchFailResponse;
+
+const handleResponse = async <T>(response: Response): Promise<FetchResponse<T>> => {
+  console.log(`${response.status} >> ${response.url}`);
+
+  // 정상 응답
+  if (response.ok) {
+    return {
+      status: FetchStatus.SUCCESS,
+      fetchResponse: await response.json(),
+    } as FetchSuccessResponse<T>;
+  }
+
+  /**
+   * handle failed HTTP Status
+   * 아래와 같은 방식으로 제어하려고 했으나, 서버 API쪽에서 이거 자체를 내려주니까 Type만 지정해서 넘겨주면 됨
+   */
+
+  // if (response.status === 404) {
+  //   return { status: 404, payload: { errorCode: 1101, errorMessage: '찾을 수 없음' } } as ErrorResponse;
+  // }
+
+  // if (response.status === 500) {
+  //   return { status: 500, payload: { errorCode: 1101, errorMessage: '먼가 잘못됨' } } as ErrorResponse;
+  // }
+
+  const res = await response.json();
+  console.log({ res });
+
+  return {
+    status: FetchStatus.FAIL,
+    fetchResponse: res,
+  } as FetchFailResponse;
+};
+
+export enum HTTPMethod {
+  GET = 'get',
+  POST = 'post',
+  PUT = 'put',
+  DELETE = 'delete',
+  PATCH = 'patch',
+}
+
+type Fetcher = {
+  [key in HTTPMethod]: <T, U = undefined>(url: string, headers?: Object, body?: U) => Promise<FetchResponse<T>>;
+};
+
+export const Fetcher: Fetcher = {
+  get: async <T>(url: string, headers = {}) => await handleResponse<T>(await fetch(url, { headers })),
+  post: async <T, U>(url: string, headers = {}, body: U) =>
+    await handleResponse<T>(
+      await fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        body: JSON.stringify(body),
+      })
+    ),
+  put: async <T, U>(url: string, headers = {}, body: U) =>
+    await handleResponse<T>(
+      await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        body: JSON.stringify(body),
+      })
+    ),
+  delete: async <T>(url: string, headers = {}) =>
+    await handleResponse<T>(
+      await fetch(url, {
+        method: 'DELETE',
+        headers,
+      })
+    ),
+  patch: async <T, U>(url: string, headers = {}, body: U) =>
+    await handleResponse<T>(
+      await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        body: JSON.stringify(body),
+      })
+    ),
+};
+
+export const requestAPI = async <T, U = undefined>(
+  method: HTTPMethod,
+  url: string,
+  headers = {},
+  body?: U
+): Promise<ActionResponse<T>> => {
+  // Network Error or CORS 오류를 처리하기 위한 요청 함수
+
+  try {
+    // 정상 응답
+    return {
+      status: ActionStatus.RESPONSED,
+      actionResponse: await Fetcher[method]<T, U>(url, headers, body),
+    } as ActionResponse<T>;
+  } catch (error) {
+    // Network Error or CORS
+    if (error instanceof Error) {
+      return {
+        status: ActionStatus.NETWORK_ERROR,
+        actionResponse: error,
+      } as ActionResponse<T>;
+    }
+    ``;
+    // TypeError가 아닌 에러 처리..인데 이런 경우는 개발할 때 throw SOMETHING 이런 거 아니면 안 넘어올 듯?
+    return {
+      status: ActionStatus.NETWORK_ERROR,
+      actionResponse: new Error(String(error)),
+    } as ActionResponse<T>;
+  }
+};

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,0 +1,16 @@
+import { FetchResponse } from '@/lib/fetcher';
+
+export enum ActionStatus {
+  RESPONSED = 'RESPONSED',
+  NETWORK_ERROR = 'NETWORK_ERROR',
+}
+
+export type ActionResponse<T> =
+  | {
+      status: ActionStatus.RESPONSED;
+      actionResponse: FetchResponse<T>;
+    }
+  | {
+      status: ActionStatus.NETWORK_ERROR;
+      actionResponse: Error;
+    };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,12 +1,6 @@
-export type SuccessResponse<T> = {
-  status: number;
-  payload: T;
-};
+export type SuccessResponse<T> = T;
 
-export type ErrorResponse = {
-  status: number;
-  payload: ErrorObject;
-};
+export type ErrorResponse = ErrorObject;
 
 export type ErrorObject = {
   errorCode: number;
@@ -15,4 +9,44 @@ export type ErrorObject = {
 
 export type APIResponse<T> = SuccessResponse<T> | ErrorResponse;
 
-export type EmptyResponse = null;
+export enum HTTPMethod {
+  GET = 'get',
+  POST = 'post',
+  PUT = 'put',
+  DELETE = 'delete',
+  PATCH = 'patch',
+}
+
+export enum FetchStatus {
+  SUCCESS = 'success',
+  FAIL = 'fail',
+  NETWORK_ERROR = 'network_error',
+  UNKNOWN_ERROR = 'unknown_error',
+}
+
+export type FetchSuccessResponse<T> = {
+  status: FetchStatus.SUCCESS;
+  data: T;
+};
+
+export type FetchFailResponse = {
+  status: FetchStatus.FAIL;
+  data: ErrorResponse;
+};
+
+/** Network Error는 TypeError를 반환 */
+export type FetchNetworkErrorResponse = {
+  status: FetchStatus.NETWORK_ERROR;
+  data: Error;
+};
+
+export type FetchUnknownErrorResponse = {
+  status: FetchStatus.UNKNOWN_ERROR;
+  data: string;
+};
+
+export type FetchResponse<T> =
+  | FetchSuccessResponse<T>
+  | FetchFailResponse
+  | FetchNetworkErrorResponse
+  | FetchUnknownErrorResponse;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,34 +1,18 @@
-/**
- * SuccessResponse는 성공한 응답을 나타내는 제네릭 타입입니다.
- * status: HTTP 상태 코드를 200으로 정의합니다.
- * payload: T는 응답의 데이터 페이로드를 나타내는데, 여기서 T는 제네릭 타입 파라미터입니다.
- */
 export type SuccessResponse<T> = {
-  status: 200;
+  status: number;
   payload: T;
 };
 
-/**
- * ErrorResponse은 실패한 응답을 나타내는 제네릭 타입입니다.
- * status: HTTP 상태 코드를 500으로 정의합니다.
- * payload: ErrorObject를 반환합니다.
- */
 export type ErrorResponse = {
-  status: 500;
+  status: number;
   payload: ErrorObject;
 };
 
-/**
- * ErrorObject는 에러와 관련된 커스텀 에러 명세를 나타내는 타입입니다.
- * errorCode: 지정된 에러 코드
- * errorMessage: 에러 메시지
- */
 export type ErrorObject = {
   errorCode: number;
   errorMessage: string;
 };
 
-/**
- * APIResponse는 성공 응답 및 에러 응답을 나타냅니다.
- */
 export type APIResponse<T> = SuccessResponse<T> | ErrorResponse;
+
+export type EmptyResponse = null;


### PR DESCRIPTION
### 관련된 이슈 번호를 기입해주세요.
> `close #이슈번호` 와 같은 형식으로 작성해주세요.

- close #62 

### 어떤 부분이 변경됐나요?
> 어떤 부분을 변경했는지, 무슨 이유로 코드를 변경했는지 설명해주세요.

- Spring Server의 배포가 HTTPS 환경에서 이루어져서 HTTPS 환경으로 Next.js를 실행하는 script 추가
  - pnpm devs
- Axios Instance 추가
  - fetch() Native API로 처리하려고 했는데, 결국 Axios가 제공하는 헤더 지정, 요청/응답 타입, 에러 처리(Network Error를 제외한 response status에 따른 오류)가 편해서 axios로 처리.
-  Axios 추가로 인한 기존 Fetcher 구조 변경
- 구조 변경하면서 필요한 타입 생성
  - Spring Server API 성공/실패 응답, Network Error 응답, Unknown Error 응답 처리
- Fetcher 구조 변경으로 인한 기존 Server Action 함수 및 Form 구조 변경
  - onSuccess로 성공 시 확장성을 생각하여 성공 콜백을 받던 것을 제거하고, Form 내부에서 처리하도록 변경   

### 추가 정보 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- HTTPS 환경으로 실행하는 devs라는 script를 작성했어요. 요거 최초 실행 시 자동으로 mkcert() 설치!
- BFF로서의 역할을 좀 적절하게 구현한 듯?
